### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ install: compile
 	@echo "  alias todo=~/.todo"
 
 uninstall:
-	rm -fr ~/.todo
+	rm -f ~/.todo
 	@echo "You can now delete this line from your configuration (~/.bashrc or ~/.zshrc etc.)"
 	@echo "  alias todo=~/.todo"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,23 +1,21 @@
-NAME = todo
+CC = cc
+CFLAGS = -Wall
 
-INC = ./
+# Executable file
+TARGET = todo
 
-SRC =	main.c \
-	buffer.c \
-	generator.c \
-	parser.c \
-	todo.c \
-	utils.c
-
-CC = gcc
-
+# Source and object files
+SRC = $(wildcard ./*.c)
 OBJ = $(SRC:c=o)
 
-$(NAME): $(OBJ)
-	$(CC) $(OBJ) -o $(NAME) -I$(INC)
 
-all: $(NAME)
+$(TARGET): $(OBJ)
+	$(CC) $(CFLAGS) $^ -o $@
+
+all: $(TARGET)
 
 clean:
-	rm -rf *.o todo
+	@echo cleaning
+	@rm -rf *.o todo
 
+.PHONY: clean


### PR DESCRIPTION
- '-r' option of rm is not necessary and unsafe
- Add '-Wall' to turn on compiler warning, all warnings should be fixed by default
