### PR TITLE
Updated Makefile and README to install to $PREFIX/{bin,man/man1}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ test*
 main
 todo
 todo.log
-.1
+*.1
 *.o
 *.out

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ test*
 main
 todo
 todo.log
+.1
 *.o
 *.out

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# invoke as "make PREFIX=/usr/local" to override PREFIX
+# invoke as "make PREFIX=/usr/local install" to override PREFIX
 # 
 
 PREFIX   	= $(HOME)
@@ -17,8 +17,8 @@ clean:
 		rm -f todo.1
 
 dirs:
-		test -d $(BINDIR)  || echo "missing $(BINDIR)"
-		test -d $(MAN1DIR) || echo "mssing $(MAN1DIR)"
+		test -d $(BINDIR)
+		test -d $(MAN1DIR)
 
 install: compile dirs todo.1
 		install src/todo $(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,35 @@
-P2M_OPTS =      -s 1 -r "Alpha" -c "github.com/hit9"
+#
+# invoke as "make PREFIX=/usr/local" to override PREFIX
+# 
 
+PREFIX   	= $(HOME)
+BINDIR 	 	= $(PREFIX)/bin
+MAN1DIR 	= $(PREFIX)/man/man1
+P2M_OPTS 	= -s 1 -r "Alpha" -c "github.com/hit9"
+
+all:	compile
+	
 compile:
-	make -C src/
+		$(MAKE) -C src/
 
 clean:
-	make -C src/ clean
+		$(MAKE) -C src/ clean
+		rm -f todo.1
 
-install: compile
-	mv src/todo ~/.todo
-	@echo "\n=====> Add the following line to your shell configuration <===== \n"
-	@echo "  alias todo=~/.todo"
+dirs:
+		test -d $(BINDIR)  || echo "missing $(BINDIR)"
+		test -d $(MAN1DIR) || echo "mssing $(MAN1DIR)"
+
+install: compile dirs todo.1
+		install src/todo $(BINDIR)
+		install todo.1 $(MAN1DIR)
 
 uninstall:
-	rm -fr ~/.todo
-	@echo "You can now delete this line from your configuration (~/.bashrc or ~/.zshrc etc.)"
-	@echo "  alias todo=~/.todo"
+		rm -f $(BINDIR)/todo
+		rm -f $(MAN1DIR)/todo.1
 
-todo.1: 	todo.pod
-			pod2man $(P2M_OPTS) $< > $@
+todo.1: todo.pod
+		pod2man $(P2M_OPTS) $< > $@
 
 test:
-	make -C src/ test
+		$(MAKE) -C src/ test

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -12,11 +12,13 @@ Installation
 
     make install
 
-This command will install `todo` to `~/.todo`.
+This command will install `todo` to `$HOME/bin` and the manual page to
+`$HOME/man/man1`.
 
-Next, add the following line to your shell's configuration(~/.bashrc or ~/.zshrc etc.):
+If you want to install into some other place than `$HOME`, invoke `make`
+with a prefix or edit the `Makefile`:
 
-    alias todo=~/.todo
+    make PREFIX=/usr/local install
 
 Usage
 -----
@@ -38,6 +40,11 @@ Examples:
   clear all tasks  -  todo clear
 ```
 
+See also the Unix manual page: 
+
+    man todo
+
+
 Storage
 -------
 
@@ -56,6 +63,10 @@ The storage format is readable, it's the [GitHub Flavored Markdown Task list](ht
 
 Manual
 ------
+
+The manual is installed into `$(HOME)/man/man1` by default. Provided
+your `man` command is configured correctly, invoking `man todo` should
+show it.
 
 ```bash
 make todo.1


### PR DESCRIPTION
Updated the Makefile to use a more idiomatic style and to install binaries and manual to paths controlled by a common `$PREFIX`. The `README` reflects these changes.